### PR TITLE
Transaction fix (#26)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,12 +10,11 @@
                leiningen.v/dependency-version-from-scm
                leiningen.v/add-workspace-data]
                
-  :dependencies [[org.neo4j.driver/neo4j-java-driver "4.1.1"]
+  :dependencies [[org.neo4j.driver/neo4j-java-driver "5.11.0"]
                  [clj-time "0.15.2"]]
-
   :profiles {:provided     {:dependencies [[org.clojure/clojure "1.10.1"]
                                            [joplin.core "0.3.11"]
-                                           [org.neo4j.test/neo4j-harness "4.0.0"]]}
+                                           [org.neo4j.test/neo4j-harness "5.10.0"]]}
              :default      [:base :system :user :provided :dev]
              :dev          [:project/dev :profiles/dev]
              :profiles/dev {}

--- a/src/neo4j_clj/core.clj
+++ b/src/neo4j_clj/core.clj
@@ -76,21 +76,18 @@ to your project?" {} t)))))
 (defn get-session [^Driver connection]
   (.session (:db connection)))
 
-(defn- make-success-transaction [tx]
+(defn- make-transaction [tx]
   (proxy [org.neo4j.driver.Transaction] []
     (run
       ([q] (.run tx q))
       ([q p] (.run tx q p)))
     (commit [] (.commit tx))
     (rollback [] (.rollback tx))
-
-    ;; We only want to auto-success to ensure persistence
     (close []
-      (.commit tx)
       (.close tx))))
 
 (defn get-transaction [^Session session]
-  (make-success-transaction (.beginTransaction session)))
+  (make-transaction (.beginTransaction session)))
 
 ;; Executing cypher queries
 
@@ -127,7 +124,11 @@ to your project?" {} t)))))
 
 (defmacro with-transaction [connection tx & body]
   `(with-open [~tx (get-transaction (get-session ~connection))]
-     ~@body))
+     (try
+       ~@body
+       (.commit ~tx)
+       (finally
+         (.close ~tx)))))
 
 (defmacro with-retry [[connection tx & {:keys [max-times] :or {max-times 1000}}] & body]
   `(retry-times ~max-times


### PR DESCRIPTION
This is intended to address issue #26 

Removed "auto-success" from `make-success-transaction` (renamed). If an exception is thrown from the body of `with-transaction` the transaction will not be committed. I'm unsure of what the original intent there was but I think this behavior is more in line with what people are likely to expect. Also updated some of the dependencies.